### PR TITLE
build(meson.build): added dl as explicit dep for linux / glibc linking

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -5,17 +5,21 @@ lib_src = files(
     'lib/utils/plugin_utils.cpp'
 )
 
+dl_dep = dependency('dl', required: true)
+
 libplugin = shared_library(
     'plugin',
     lib_src,
     install : true,
     include_directories : include,
+    dependencies : [dl_dep],
     cpp_args : ['-fPIC']
 )
 
 plugin_dep = declare_dependency(
     link_with : libplugin,
-    include_directories : include
+    include_directories : include,
+    dependencies : [dl_dep],
 )
 
 include_files_base = files(


### PR DESCRIPTION
glibc needs dl linked explicitly in a way that libSystem on macOS does not. dl has been added as a dependency to libplugin. 