### PR TITLE
Fixed symbol visibility on linux

### DIFF
--- a/src/lib/manager/plugin_manager.cpp
+++ b/src/lib/manager/plugin_manager.cpp
@@ -45,7 +45,7 @@ namespace fourdst::plugin {
             throw exception::PluginLoadError("Plugin library not found at path: " + library_path.string());
         }
 
-        void* handle = dlopen(library_path.c_str(), RTLD_LAZY);
+        void* handle = dlopen(library_path.c_str(), RTLD_LAZY | RTLD_GLOBAL);
         if (!handle) {
             throw exception::PluginLoadError("Failed to load library '" + library_path.string() + "'. Error: " + dlerror());
         }

--- a/src/lib/manager/plugin_manager.cpp
+++ b/src/lib/manager/plugin_manager.cpp
@@ -1,9 +1,6 @@
 #include "fourdst/plugin/manager/plugin_manager.h"
 #include "fourdst/plugin/factory/plugin_factory.h"
 
-const char* fourdst::plugin::g_plugin_name = nullptr;
-const char* fourdst::plugin::g_plugin_version = nullptr;
-
 #include <dlfcn.h>
 #include <map>
 #include <memory>


### PR DESCRIPTION
glibc and linux enforces stricter symbol visibility rules; added RTLD_GLOBAL flag to dlopen to allow for dynamically linked symbols to be found at runtime.